### PR TITLE
🚧 [YOUTUBE API] key 값 넘어가는 부분 수정

### DIFF
--- a/src/youtube/SearchYoutube.jsx
+++ b/src/youtube/SearchYoutube.jsx
@@ -54,8 +54,8 @@ function SearchYoutube() {
   };
   // 403 에러가 뜨면 가장 앞의 키 값을 제거함
   const selectNextKey = () => {
-    API_KEYS = API_KEYS.slice(1); // 맨 앞의 키값을 삭제 하고 적용,
-    setCurrentKeyIndex(0); // 첫 번째 키를 현재 키 인덱스로 설정합니다.
+    API_KEYS = API_KEYS.slice(1); // 맨 앞의 키값을 삭제 하고 적용
+    setCurrentKeyIndex(0); // 첫 번째 키를 현재 키 인덱스로 설정
   };
 
   const searchYoutube = async () => {

--- a/src/youtube/SearchYoutube.jsx
+++ b/src/youtube/SearchYoutube.jsx
@@ -8,9 +8,7 @@ import axios from 'axios';
 // 초기 KEY값이랑 복사본 KEY값 생성
 const INITIAL_API_KEYS = import.meta.env.VITE_YOUTUBE_API.split(','); // 초기 KEY 값
 // let으로 선언한 이유: 변수의 값을 변경하기 때문에(const는 불가능!)
-let API_KEYS = [...INITIAL_API_KEYS]; // 복사본 KEY값
-
-const MAX_API_KEYS = API_KEYS.length;
+let API_KEYS = [...INITIAL_API_KEYS]; // 복사본 KEY값, 이 것을 키 값으로 사용핳 것임
 
 function SearchYoutube() {
   const axiosInstance = axios.create({
@@ -54,9 +52,10 @@ function SearchYoutube() {
   const restoreKeys = () => {
     API_KEYS = [...INITIAL_API_KEYS]; // 초기 키 값으로 복구(이 부분 때문에 위에서 let을 쓴 것임)
   };
-
+  // 403 에러가 뜨면 가장 앞의 키 값을 제거함
   const selectNextKey = () => {
-    setCurrentKeyIndex(prevIndex => (prevIndex + 1) % MAX_API_KEYS);
+    API_KEYS = API_KEYS.slice(1); // 맨 앞의 키값을 삭제 하고 적용,
+    setCurrentKeyIndex(0); // 첫 번째 키를 현재 키 인덱스로 설정합니다.
   };
 
   const searchYoutube = async () => {

--- a/src/youtube/SearchYoutube.jsx
+++ b/src/youtube/SearchYoutube.jsx
@@ -1,12 +1,15 @@
 // 유튜브 API 컨테이너 컴포넌트
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './youtube.module.css';
 import SearchResult from './SearchResult';
 import CreateList from '@youtube/CreateList';
-
 import axios from 'axios';
 
-const API_KEYS = import.meta.env.VITE_YOUTUBE_API.split(',');
+// 초기 KEY값이랑 복사본 KEY값 생성
+const INITIAL_API_KEYS = import.meta.env.VITE_YOUTUBE_API.split(','); // 초기 KEY 값
+// let으로 선언한 이유: 변수의 값을 변경하기 때문에(const는 불가능!)
+let API_KEYS = [...INITIAL_API_KEYS]; // 복사본 KEY값
+
 const MAX_API_KEYS = API_KEYS.length;
 
 function SearchYoutube() {
@@ -19,6 +22,38 @@ function SearchYoutube() {
   const [searchResult, setSearchResult] = useState([]);
   const [selectedVideos, setSelectedVideos] = useState([]);
   const [currentVideoIndex, setCurrentVideoIndex] = useState(0);
+
+  // 매일 오후 4시에 KEY값을 원래대로 초기화(초기 KEY 값으로 설정하는 코드)
+  useEffect(() => {
+    // setInterval 함수는 주어진 시간 간격마다 특정한 함수를 반복적으로 실행(JavaScript의 내장 함수)
+    const interval = setInterval(() => {
+      const current = new Date(); // 현재 시간을 나타냄
+
+      // 오후 4시를 계산 하는 식
+      // new Date(현재 연도,현재 월[0부터 시작(ex: 1월은 0)],현재날짜,시,분,초,밀리초)
+      const resetTime = new Date(
+        current.getFullYear(),
+        current.getMonth(),
+        current.getDate(),
+        16,
+        0,
+        0,
+        0,
+      ).getTime();
+      const currentTime = current.getTime();
+
+      // 현재 시간이 오후 4시와 동일하묜 키 값울 초기 값으로 리셋
+      if (currentTime === resetTime) {
+        restoreKeys();
+      }
+    }, 1000); // 1초 간격으로 체크
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const restoreKeys = () => {
+    API_KEYS = [...INITIAL_API_KEYS]; // 초기 키 값으로 복구(이 부분 때문에 위에서 let을 쓴 것임)
+  };
 
   const selectNextKey = () => {
     setCurrentKeyIndex(prevIndex => (prevIndex + 1) % MAX_API_KEYS);

--- a/src/youtube/SearchYoutube.jsx
+++ b/src/youtube/SearchYoutube.jsx
@@ -55,7 +55,7 @@ function SearchYoutube() {
   // 403 에러가 뜨면 가장 앞의 키 값을 제거함
   const selectNextKey = () => {
     API_KEYS = API_KEYS.slice(1); // 맨 앞의 키값을 삭제 하고 적용
-    setCurrentKeyIndex(0); // 첫 번째 키를 현재 키 인덱스로 설정
+    setCurrentKeyIndex(0); // 삭제 된 후, 첫 번째 키를 현재 키 인덱스로 설정
   };
 
   const searchYoutube = async () => {


### PR DESCRIPTION
403에러가 뜨면 다음 키로 넘어가는 과정 수정

이슈
다음 키(두 번째 키)로 넘어간 후, 그 키 값이 유지 된 채로 YOUTUBE API를 사용하는 것이 아니라
첫 번째 키부터 다시 시작해서 다시 403 에러를 보고 두 번째 키로 넘어가는 과정이 YOUTUBE API를 사용할 때마다 반복
사용자 입장에서 여러 번 클릭해야지 노래 검색, 듣기 및 업로드를 할 수 있음

해결 방법
원본 키를 복사해둔 후 복사본을 사용함
복사본은 403에러가 뜰 시 `slice`를 사용해서 첫 번째 키를 삭제 함
그 후 오후 4시마다 원본 키를 복사해서 새롭게 사용 